### PR TITLE
Mask pump in slow phi0 fit

### DIFF
--- a/src/correct_slow_phi_0.py
+++ b/src/correct_slow_phi_0.py
@@ -22,12 +22,14 @@ def parse_args():
 def load_phi_0(args):
     with h5py.File(args.filename) as h5:
         phi_0_ds = h5["raw_phase_offsets"]
+        p_value_ds = h5["p_values"]
         if args.scans == "all":
             scans = range(phi_0_ds.shape[0])
         else:
             scans = args.scans
         phi_0 = phi_0_ds[scans]
-    return phi_0
+        p_values = p_value_ds[scans]
+    return phi_0, p_values
 
 
 def unfold(phi_0):
@@ -42,12 +44,12 @@ def unfold(phi_0):
     return pr*pi
 
 
-def calculate_slow_phi_0s(phi_0s):
+def calculate_slow_phi_0s(phi_0s, p_values):
     slow_phi_0s = scipy.empty_like(phi_0s)
     for i, phi_0 in enumerate(phi_0s):
         phi_0_unfolded = unfold(phi_0)
         x = arange(len(phi_0_unfolded))
-        model = polyfit(x, phi_0_unfolded, 3)
+        model = polyfit(x, phi_0_unfolded, 3, w=p_values[i])
         slow_phi_0s[i] = polyval(model, x)
     return slow_phi_0s
 
@@ -70,8 +72,8 @@ def correct_angles(args, phi_0s, slow_phi_0s):
 
 def main():
     args = parse_args()
-    phi_0s = load_phi_0(args)
-    slow_phi_0s = calculate_slow_phi_0s(phi_0s)
+    phi_0s, p_values = load_phi_0(args)
+    slow_phi_0s = calculate_slow_phi_0s(phi_0s, p_values)
     correct_angles(args, phi_0s, slow_phi_0s)
 
 


### PR DESCRIPTION
The intense pump pulse can throw off the polynomial phi0 fit.
With this patch we use p_values from the cosine fit as weights for slow phi_0 fit to effectively mask the pump.

Signed-off-by: Martina Esposito martina.esposito@elettra.eu
